### PR TITLE
Update 2c7c0801 for RM520N-GL and RM521F-GL

### DIFF
--- a/modemband/files/usr/share/modemband/2c7c0801
+++ b/modemband/files/usr/share/modemband/2c7c0801
@@ -1,12 +1,15 @@
-_DEVICE=/dev/ttyUSB2
+_DEVICE=/dev/ttyUSB3
 _DEFAULT_LTE_BANDS="1 2 3 4 5 7 8 12 13 14 17 18 19 20 25 26 28 29 30 32 34 38 39 40 41 42 43 46 48 66 71"
 _DEFAULT_5GNSA_BANDS="1 2 3 5 7 8 12 13 14 18 20 25 26 28 29 30 38 40 41 48 66 70 71 75 76 77 78 79"
 _DEFAULT_5GSA_BANDS="1 2 3 5 7 8 12 13 14 18 20 25 26 28 29 30 38 40 41 48 66 70 71 75 76 77 78 79"
 
 getinfo() {
-	echo "Quectel RM520N-GL"
+    VENDOR=$(sms_tool -d /dev/ttyUSB3 at AT+CGMI | tr -s '\n' | xargs)
+    DEVICE=$(sms_tool -d /dev/ttyUSB3 at AT+CGMM | tr -s '\n' | xargs)
+    echo "$VENDOR $DEVICE"
 }
 
-# +QNWPREFCFG: "lte_band",1:3:7:8:20:28:38
+# +QNWPREFCFG: "lte_band",1:2:3:4:5:7:8:12:13:14:17:18:19:20:25:26:28:29:30:32:34:38:39:40:41:42:43:46:48:66:71
+# +QNWPREFCFG: "nsa_nr5g_band",1:2:3:5:7:8:12:13:14:18:20:25:26:28:29:30:38:40:41:48:66:70:71:75:76:77:78:79
 
 . $RES/_quectel_common2


### PR DESCRIPTION
There are two modems that correspond to Quectel's 0x2c7c (vendor id) and device ID 0x0801, RM520N-GL and RM521F-GL.

This simple function uses sms-tool to obtain this information directly from the modem