### PR TITLE
Add support for Fibocom FG621-EA

### DIFF
--- a/modemband/modemband/files/usr/share/modemband/2cb70a05
+++ b/modemband/modemband/files/usr/share/modemband/2cb70a05
@@ -1,0 +1,51 @@
+# Fibocom FG621-EA
+# Based on _fibocom_fm350_common with 5G portions removed
+
+_DEVICE=/dev/ttyUSB0
+
+getinfo() {
+  O=$(sms_tool -d $_DEVICE at "AT+CGMM?")
+  _NAME="Fibocom $(echo "$O" | awk -F[:,] '/^\+CGMM:/{gsub("\"","");print $2}' | xargs)"
+  echo "$_NAME"
+}
+
+getsupportedbands() {
+    _DEFAULT_LTE_BANDS="1 3 5 7 8 20 28 38 40 41"
+    echo "$_DEFAULT_LTE_BANDS"
+}
+
+getbands() {
+    # +GTACT: 10,3,2,1,3,5,8,101,103,105,107,108,120,128,138,140,141
+
+    O=$(sms_tool -d $_DEVICE at "AT+GTACT?")
+    BANDS=$(echo "$O" | awk -F: '/^\+GTACT:/{gsub(","," ");print $2}')
+    for BAND in $BANDS; do
+        if [ $BAND -gt 100 ] && [ $BAND -lt 200 ]; then
+            echo -n "$((BAND - 100)) "
+        fi
+    done
+    echo ""
+}
+
+setbands() {
+    BANDS="$1"
+
+    T=""
+    if [ "$BANDS" = "default" ]; then
+        T="0"
+    else
+        for BAND in $BANDS; do
+            case $BAND in
+                ''|*[!0-9]*) continue ;;
+            esac
+            [ -n "$T" ] && T="${T},"
+            T="${T}$((BAND + 100))"
+        done
+    fi
+
+    if [ -n "$T" ]; then
+        O=$(sms_tool -d $_DEVICE at "AT+GTACT?")
+        MODE=$(echo "$O" | awk -F[:,] '/\+GTACT:/{print $2","$3","$4}'| xargs)
+        sms_tool -d $_DEVICE at "AT+GTACT=$MODE,$T"
+    fi
+}


### PR DESCRIPTION
This modem is used in:
TP-Link TL-MR500v1
Asus 4G-AX56

Based on _fibocom_fm350_common with updated LTE bands list (and 5G functionality removed).

<img width="1200" height="799" alt="Custom LTE bands" src="https://github.com/user-attachments/assets/fff01391-33f2-4d8d-b0a7-96152927237c" />
